### PR TITLE
Ensure V3 physics loads before engine

### DIFF
--- a/index.html
+++ b/index.html
@@ -644,9 +644,10 @@
     </div>
 
     <!-- Scripts V3 (Legacy) -->
+    <!-- Load physics first so the engine and V4 app can use it -->
+    <script src="js/v3-physics.js"></script>
     <script src="js/v3-audio.js"></script>
     <script src="js/v3-graphics.js"></script>
-    <script src="js/v3-physics.js"></script>
     <script src="js/v3-networking.js"></script>
     <script src="js/v3-engine.js"></script>
 
@@ -658,6 +659,7 @@
     <script src="js/v4-game-logic.js"></script>
     <script src="js/v4-tasks-system.js"></script>
     <script src="js/v4-networking.js"></script>
+    <!-- Ensure the main V4 app loads after the legacy engine -->
     <script src="js/v4-app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load legacy physics script ahead of engine and V4 app to prevent `AmongUsV3Physics` undefined
- clarify script-order dependencies in HTML

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c62e53178832ba100d41bb694f271