### PR TITLE
Preload ambient audio in test page

### DIFF
--- a/test-audio.html
+++ b/test-audio.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Audio System Test</title>
+    <link rel="preload" href="assets/sounds/ambient.wav" as="audio" type="audio/wav">
     <style>
         body {
             font-family: Arial, sans-serif;


### PR DESCRIPTION
## Summary
- Preload ambient audio in test page with a valid `as="audio"` attribute to avoid unsupported value warnings

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Among-US/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689c62df28f4832bbba448902c8c88e4