### PR TITLE
Start networking after full initialization

### DIFF
--- a/js/v4-app.js
+++ b/js/v4-app.js
@@ -3,6 +3,7 @@ class AmongUsV4App {
     constructor() {
         this.currentScreen = 'loading';
         this.isInitialized = false;
+        this.appReady = false;
         
         // Systèmes avancés
         this.audioSystem = null;
@@ -147,6 +148,7 @@ class AmongUsV4App {
         // Initialiser le réseau
         this.updateLoadingProgress(85, 'Connexion réseau...');
         this.networkingSystem = new NetworkingSystem(this);
+        this.networkingSystem.init();
         
         // Créer le joueur local
         this.updateLoadingProgress(90, 'Création du personnage...');
@@ -297,6 +299,11 @@ class AmongUsV4App {
     
     completeInitialization() {
         this.isInitialized = true;
+        this.appReady = true;
+
+        if (this.networkingSystem) {
+            this.networkingSystem.start();
+        }
         
         // Masquer l'écran de chargement
         setTimeout(() => {

--- a/js/v4-networking.js
+++ b/js/v4-networking.js
@@ -27,16 +27,18 @@ class NetworkingSystem {
         // Messages en attente
         this.messageQueue = [];
         this.lastHeartbeat = Date.now();
-        
-        this.init();
     }
-    
+
     init() {
         console.log('🌐 Initializing Networking System...');
-        
+
         // Générer un ID de joueur unique
         this.playerId = this.generatePlayerId();
-        
+    }
+
+    start() {
+        console.log('🚀 Starting Networking System...');
+
         // Simuler la connexion réseau pour la démo
         this.simulateNetworking();
     }


### PR DESCRIPTION
## Summary
- Initialize the networking system without starting its heartbeat.
- Add explicit `start()` call so networking begins only after the app is ready.

## Testing
- `node --check js/v4-networking.js js/v4-app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c65b96e3c832ba54e39380cc5febd