### PR TITLE
Use generic fetch preload for audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     
     <!-- Preload critical resources -->
     <link rel="preload" href="assets/characters/crew-red-sheet.png" as="image">
-    <link rel="preload" href="assets/sounds/ambient.wav" as="audio" type="audio/wav">
+    <link rel="preload" href="assets/sounds/ambient.wav" as="fetch" type="audio/wav">
     
     <style>
         /* Styles de base pour le canvas de jeu */

--- a/js/v3-audio.js
+++ b/js/v3-audio.js
@@ -440,7 +440,7 @@ class AmongUsV3Audio {
     
     async tryPreloadedResource(url) {
         // Check if the resource was preloaded
-        const preloadLinks = document.querySelectorAll('link[rel="preload"][as="audio"]');
+        const preloadLinks = document.querySelectorAll('link[rel="preload"][as="fetch"][type^="audio/"]');
         for (let link of preloadLinks) {
             if (link.href.includes(url) || url.includes(link.getAttribute('href'))) {
                 try {
@@ -458,7 +458,7 @@ class AmongUsV3Audio {
     
     usePreloadedResources() {
         // This method ensures preloaded resources are "used" to prevent browser warnings
-        const preloadLinks = document.querySelectorAll('link[rel="preload"][as="audio"]');
+        const preloadLinks = document.querySelectorAll('link[rel="preload"][as="fetch"][type^="audio/"]');
         preloadLinks.forEach(link => {
             const url = link.getAttribute('href');
             if (url) {

--- a/test-audio.html
+++ b/test-audio.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Audio System Test</title>
-    <link rel="preload" href="assets/sounds/ambient.wav" as="audio" type="audio/wav">
+    <link rel="preload" href="assets/sounds/ambient.wav" as="fetch" type="audio/wav">
     <style>
         body {
             font-family: Arial, sans-serif;


### PR DESCRIPTION
## Summary
- Avoid browser warning by preloading audio as `fetch` instead of unsupported `as="audio"`
- Adjust audio helper to detect preloaded audio via `as="fetch"`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c67c81898832bb965c1239651ec4e