### PR TITLE
Remove ambient audio preload causing credentials mismatch warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
     
     <!-- Preload critical resources -->
     <link rel="preload" href="assets/characters/crew-red-sheet.png" as="image">
-    <link rel="preload" href="assets/sounds/ambient.wav" as="fetch" type="audio/wav">
     
     <style>
         /* Styles de base pour le canvas de jeu */

--- a/test-audio.html
+++ b/test-audio.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Audio System Test</title>
-    <link rel="preload" href="assets/sounds/ambient.wav" as="fetch" type="audio/wav">
     <style>
         body {
             font-family: Arial, sans-serif;


### PR DESCRIPTION
## Summary
- Remove unused preload of ambient audio to stop console credential mismatch warning
- Drop ambient preload reference from audio test page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c77d4857c832ba45819e86977cdc1